### PR TITLE
Change the parameters of the SwiGLU kernels to vectors

### DIFF
--- a/swiglu.py
+++ b/swiglu.py
@@ -21,8 +21,8 @@ def swiglu_kernel(
 
 
 def ninetoothed_swiglu(a, b):
-    a_1d = a.view(-1)
-    b_1d = b.view(-1)
+    a_1d = a.flatten()
+    b_1d = b.flatten()
 
     c = torch.empty_like(a_1d)
 


### PR DESCRIPTION
 - Change the inputs of the NineToothed kernel to 1D vectors by modifying their views in ninetoothed_swiglu() function